### PR TITLE
Fix: add ** to js files and add output directory

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,9 +1,10 @@
 const purgecss = require('@fullhuman/postcss-purgecss')({
   content: [
+    './output/**/*.html',
     './src/**/*.html',
     './src/**/*.liquid',
     './src/**/*.md',
-    './frontend/javascript/*.js'
+    './frontend/javascript/**/*.js'
   ],
   output: './output/_bridgetown/static/css',
   defaultExtractor: content => {


### PR DESCRIPTION
*.js does not recurse through.

If you don't add the output directory, markdown parsing will get jacked up if you're importing a stylesheet via javascript